### PR TITLE
Add service_type to Task model and align handlers with task_id

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ def get_db():
 def submit_task(service_type: str = Form(...), db: Session = Depends(get_db)):
     # 提交单个任务，生成唯一 task_id，入库并异步触发 Celery 任务
     task_id = str(uuid.uuid4())
-    db_task = Task(id=task_id, service_type=service_type, status='Pending')
+    db_task = Task(task_id=task_id, service_type=service_type, status='Pending')
     db.add(db_task)
     db.commit()
     process_task.delay(task_id, service_type)  # 触发 Celery
@@ -40,10 +40,10 @@ def submit_task(service_type: str = Form(...), db: Session = Depends(get_db)):
 @app.get("/tasks/{task_id}")
 def get_task(task_id: str, db: Session = Depends(get_db)):
     # 查询单个任务进度（优先 Redis，回退数据库），返回任务状态和进度百分比
-    task = db.query(Task).filter(Task.id == task_id).first()
+    task = db.query(Task).filter(Task.task_id == task_id).first()
     if not task:
         raise HTTPException(404, "Task not found")
-    progress = redis_client.get(f'task_progress:{task_id}') or task.progress
+    progress = redis_client.get(f'task_progress:{task_id}') or task.percent
     return {"status": task.status, "progress": int(progress)}
 
 @app.get("/tasks/{task_id}/events")

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class Task(Base):
     __tablename__ = 'tasks'
     task_id = Column(String, primary_key=True)
     user_id = Column(String)
+    service_type = Column(String)
     status = Column(String)  # 总状态
     current_stage = Column(String)  # 当前阶段
     percent = Column(Float)  # 总进度


### PR DESCRIPTION
## Summary
- add `service_type` column to `Task` model
- use `task_id` field consistently in task submission and lookup
- rely on existing `percent` field for progress and drop unused `id`/`progress` fields

## Testing
- `python -m py_compile models.py main.py tasks.py`
- `pytest -q`
- `python - <<'PY'
from database import engine
from models import Base
Base.metadata.drop_all(bind=engine)
Base.metadata.create_all(bind=engine)
print('DB tables reset')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689e964566f88333a4c219443ec85c98